### PR TITLE
embed_example.html: Fix comments about date format

### DIFF
--- a/widget/embed_example.html
+++ b/widget/embed_example.html
@@ -26,8 +26,8 @@
     };
         
     var params = 
-        {   from: "today",             //Start date range - dd/mm/yy. Required
-            //to: null,                   //end date range, - dd/mm/yy
+        {   from: "today",             //Start date range - YYYY-MM-DD. Required
+            //to: null,                   //end date range, - YYYY-MM-DD
             //speakers: [],               //array of speaker slugs
             //venues: [],                 //array of oxpoints IDs
             //organising_departments: [], //array of oxpoints IDs


### PR DESCRIPTION
The correct date format for from/today parameters is YYYY-MM-DD, not dd-mm-yyyy.

For example, using `from: '20/09/2015'` results in a request to 
https://talks.ox.ac.uk/api/talks/search?from=20/09/2015&series=bb1262a7-73bd-4cb1-adbd-ed78a9df6d4c&count=100
which gives an error.

Whereas using `from: '2015-09-20'` results in a request to 
https://talks.ox.ac.uk/api/talks/search?from=2015-09-20&series=bb1262a7-73bd-4cb1-adbd-ed78a9df6d4c&count=100
which works
