### PR TITLE
Retain paragaph formatting in abstract/description

### DIFF
--- a/widget/embed_ox_talks.js
+++ b/widget/embed_ox_talks.js
@@ -85,8 +85,8 @@ var oxtalks = {
             header = $('<h3>' + talk_title + '</h3>');
             element.append(header);
 
-            description = $('<p>');
-            description.html(talk.description);
+            description = $('<div>');
+            description.html('<p>' + talk.description.replace(/[\n\r]+/g, '&nbsp;</p><p>') + '</p>');
             element.append(description);
 
             bullets = $('<ul>');


### PR DESCRIPTION
A talk's abstract may contain newlines to separate paragraphs (for example, an abstract and speaker's bio may both be recorded in the 'abstract' field, as there is no separate bio field). However, these were not currently being displayed in the list view.